### PR TITLE
Add Rocket shared props

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ let shared_props = SharedProps::new()
 let rocket = rocket::build().manage(shared_props);
 ```
 
-Shared props are shallow-merged into page props for HTML first loads and JSON Inertia responses. Route props win on key collisions. Keys may be top-level or dotted, where `auth.user` becomes `props.auth.user`; inserted top-level keys are listed in `sharedProps`. Keep shared props small and namespace them, since they are merged after partial-reload filtering and remain included on partial reload responses.
+Shared props are shallow-merged into page props for HTML first loads and JSON Inertia responses. Route props win on key collisions, including when a route-defined root such as `auth` collides with dotted shared keys such as `auth.user`. Keys may be top-level or dotted, where `auth.user` becomes `props.auth.user`; inserted top-level keys are listed in `sharedProps`. Keep shared props small and namespace them, since they are merged after partial-reload filtering and remain included on partial reload responses.
 
 ## Redirect Helpers
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The simple API remains the shortest path for standard pages:
 Inertia::response("Users/Index", props)
 ```
 
-For v3 page metadata, chain explicit helpers on the response or use the `Inertia::page(...).props(...)` builder. Deferred props are listed in `deferredProps` and omitted until an Inertia partial reload explicitly requests them; this crate does not yet provide lazy async prop resolvers. `share()` only marks `sharedProps` metadata and does not register global shared application state.
+For v3 page metadata, chain explicit helpers on the response or use the `Inertia::page(...).props(...)` builder. Deferred props are listed in `deferredProps` and omitted until an Inertia partial reload explicitly requests them; this crate does not yet provide lazy async prop resolvers. `share()` marks `sharedProps` metadata, while the Rocket integration can register shared application state as shown below.
 
 ```rust
 Inertia::response("Users/Index", props)
@@ -127,6 +127,24 @@ use inertia_rs::{Page, PageMetadata, RequestContext};
 ```
 
 Rocket responses use these types internally. `RequestContext` parses Inertia headers such as `X-Inertia-Partial-Data`, `X-Inertia-Partial-Except`, `X-Inertia-Reset`, and `X-Inertia-Except-Once-Props`.
+
+## Rocket Shared Props
+
+Register `rocket::SharedProps` as managed state to merge common application data into every Rocket page response.
+
+```rust
+use inertia_rs::rocket::SharedProps;
+
+let shared_props = SharedProps::new()
+    .value("appName", "My App")
+    .prop("auth.csrfToken", |request| {
+        request.headers().get_one("X-CSRF").map(ToOwned::to_owned)
+    });
+
+let rocket = rocket::build().manage(shared_props);
+```
+
+Shared props are shallow-merged into page props for HTML first loads and JSON Inertia responses. Route props win on key collisions. Keys may be top-level or dotted, where `auth.user` becomes `props.auth.user`; inserted top-level keys are listed in `sharedProps`. Keep shared props small and namespace them, since they are merged after partial-reload filtering and remain included on partial reload responses.
 
 ## Redirect Helpers
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,16 @@ fn empty_map<K, V>(map: &BTreeMap<K, V>) -> bool {
     map.is_empty()
 }
 
+#[derive(Clone, Debug, Default)]
+struct RouteProps(Vec<String>);
+
+// Internal responder bookkeeping should not affect protocol-level Page equality.
+impl PartialEq for RouteProps {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
 fn prop_root(prop: &str) -> &str {
     prop.split_once('.')
         .map(|(root, _suffix)| root)
@@ -763,7 +773,7 @@ pub struct Page<T> {
     #[serde(skip_serializing_if = "empty_map")]
     deferred_props: BTreeMap<String, Vec<String>>,
     #[serde(skip)]
-    route_props: Vec<String>,
+    route_props: RouteProps,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     rescued_props: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -800,7 +810,7 @@ impl<T> Page<T> {
             match_props_on: metadata.match_props_on,
             scroll_props: metadata.scroll_props,
             deferred_props: metadata.deferred_props,
-            route_props: Vec::new(),
+            route_props: RouteProps::default(),
             rescued_props: metadata.rescued_props,
             shared_props: metadata.shared_props,
             once_props: metadata.once_props,
@@ -854,10 +864,10 @@ impl Page<Value> {
             .as_object_mut()
             .expect("props was normalized to an object");
         ensure_errors_prop(props);
-        let route_roots = if self.route_props.is_empty() {
+        let route_roots = if self.route_props.0.is_empty() {
             props.keys().cloned().collect::<BTreeSet<_>>()
         } else {
-            self.route_props.iter().cloned().collect()
+            self.route_props.0.iter().cloned().collect()
         };
 
         for (key, value) in shared_props {
@@ -1257,7 +1267,7 @@ impl<T: Serialize> Inertia<T> {
         let metadata = metadata.for_response(request, &component, props.as_object());
 
         let mut page = Page::from_parts(component, props, url, version, metadata);
-        page.route_props = route_props;
+        page.route_props = RouteProps(route_props);
 
         Ok(page)
     }
@@ -1578,5 +1588,38 @@ mod tests {
             value["onceProps"]["billing"],
             json!({ "prop": "plans", "expiresAt": 123 })
         );
+    }
+
+    #[test]
+    fn page_equality_ignores_internal_route_prop_tracking() {
+        let request = request_context_from(&[]);
+        let response = Inertia::response(
+            "Users",
+            json!({
+                "auth": {
+                    "user": {
+                        "name": "Ada"
+                    }
+                }
+            }),
+        )
+        .into_page("/users", Some("version-1".into()), &request)
+        .unwrap();
+        let manual = Page::from_parts(
+            "Users",
+            json!({
+                "errors": {},
+                "auth": {
+                    "user": {
+                        "name": "Ada"
+                    }
+                }
+            }),
+            "/users",
+            Some("version-1".into()),
+            PageMetadata::new(),
+        );
+
+        assert_eq!(response, manual);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,6 +762,8 @@ pub struct Page<T> {
     scroll_props: BTreeMap<String, ScrollProps>,
     #[serde(skip_serializing_if = "empty_map")]
     deferred_props: BTreeMap<String, Vec<String>>,
+    #[serde(skip)]
+    route_props: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     rescued_props: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -798,6 +800,7 @@ impl<T> Page<T> {
             match_props_on: metadata.match_props_on,
             scroll_props: metadata.scroll_props,
             deferred_props: metadata.deferred_props,
+            route_props: Vec::new(),
             rescued_props: metadata.rescued_props,
             shared_props: metadata.shared_props,
             once_props: metadata.once_props,
@@ -851,7 +854,11 @@ impl Page<Value> {
             .as_object_mut()
             .expect("props was normalized to an object");
         ensure_errors_prop(props);
-        let route_roots = props.keys().cloned().collect::<BTreeSet<_>>();
+        let route_roots = if self.route_props.is_empty() {
+            props.keys().cloned().collect::<BTreeSet<_>>()
+        } else {
+            self.route_props.iter().cloned().collect()
+        };
 
         for (key, value) in shared_props {
             let key = key.into();
@@ -1241,11 +1248,18 @@ impl<T: Serialize> Inertia<T> {
         let component = self.component;
         let metadata = self.metadata;
         let mut props = serde_json::to_value(self.props)?;
+        let route_props = props
+            .as_object()
+            .map(|props| props.keys().cloned().collect())
+            .unwrap_or_default();
 
         request.filter_props(&component, &mut props, &metadata);
         let metadata = metadata.for_response(request, &component, props.as_object());
 
-        Ok(Page::from_parts(component, props, url, version, metadata))
+        let mut page = Page::from_parts(component, props, url, version, metadata);
+        page.route_props = route_props;
+
+        Ok(page)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,30 @@ fn ensure_errors_prop(props: &mut Map<String, Value>) {
         .or_insert_with(|| Value::Object(Map::new()));
 }
 
+fn insert_shared_prop_path(props: &mut Map<String, Value>, path: &[&str], value: Value) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+
+    if path.len() == 1 {
+        if props.contains_key(path[0]) {
+            return false;
+        }
+
+        props.insert(path[0].to_owned(), value);
+        return true;
+    }
+
+    let entry = props
+        .entry(path[0].to_owned())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(nested) = entry else {
+        return false;
+    };
+
+    insert_shared_prop_path(nested, &path[1..], value)
+}
+
 fn string_set(values: &[String]) -> BTreeSet<&str> {
     values.iter().map(String::as_str).collect()
 }
@@ -804,6 +828,47 @@ impl<T> Page<T> {
     /// Returns the asset version, if present.
     pub fn asset_version(&self) -> Option<&str> {
         self.version.as_deref()
+    }
+}
+
+impl Page<Value> {
+    /// Merges shared props into the page object.
+    ///
+    /// Existing page props take precedence when keys collide. Dotted keys are
+    /// expanded into nested objects, and inserted top-level keys are added to
+    /// the page object's `sharedProps` metadata.
+    pub fn with_shared_props<I, K>(mut self, shared_props: I) -> Self
+    where
+        I: IntoIterator<Item = (K, Value)>,
+        K: Into<String>,
+    {
+        if !self.props.is_object() {
+            self.props = Value::Object(Map::new());
+        }
+
+        let props = self
+            .props
+            .as_object_mut()
+            .expect("props was normalized to an object");
+        ensure_errors_prop(props);
+
+        for (key, value) in shared_props {
+            let key = key.into();
+            let path = key
+                .split('.')
+                .filter(|segment| !segment.is_empty())
+                .collect::<Vec<_>>();
+            let Some(root) = path.first() else {
+                continue;
+            };
+            let root = (*root).to_owned();
+
+            if insert_shared_prop_path(props, &path, value) && !self.shared_props.contains(&root) {
+                self.shared_props.push(root);
+            }
+        }
+
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,7 @@ impl Page<Value> {
             .as_object_mut()
             .expect("props was normalized to an object");
         ensure_errors_prop(props);
+        let route_roots = props.keys().cloned().collect::<BTreeSet<_>>();
 
         for (key, value) in shared_props {
             let key = key.into();
@@ -862,6 +863,10 @@ impl Page<Value> {
                 continue;
             };
             let root = (*root).to_owned();
+
+            if route_roots.contains(&root) {
+                continue;
+            }
 
             if insert_shared_prop_path(props, &path, value) && !self.shared_props.contains(&root) {
                 self.shared_props.push(root);

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -11,10 +11,17 @@ use rocket::serde::json::Json;
 use rocket::Data;
 use rocket::{error, get, routes, uri};
 use serde::Serialize;
+use serde_json::Value;
 use std::sync::Arc;
 use tracing::trace;
 
 const BASE_ROUTE: &str = "/inertia-rs";
+
+type SharedPropProvider = Arc<
+    dyn for<'request, 'rocket> Fn(&'request Request<'rocket>) -> Result<Value, serde_json::Error>
+        + Send
+        + Sync,
+>;
 
 fn request_context(request: &Request<'_>) -> RequestContext {
     RequestContext::from_header_fn(|name| request.headers().get_one(name))
@@ -42,6 +49,77 @@ impl InertiaHeaders {
     /// Returns the parsed request context.
     pub fn context(&self) -> &RequestContext {
         &self.context
+    }
+}
+
+/// Shared Inertia props resolved for every Rocket page response.
+///
+/// Register this as Rocket managed state with [`rocket::Rocket::manage`].
+/// Shared props are shallow-merged into page props; route props win on key
+/// collisions. Providers run once per page response and may inspect the
+/// current request. Dotted keys, such as `auth.user`, are expanded into
+/// nested props.
+///
+/// Shared props are merged after partial-reload filtering, so they remain
+/// present on partial responses even when omitted from `only` or `except`
+/// reload options.
+///
+/// ```rust
+/// use inertia_rs::rocket::SharedProps;
+///
+/// let shared_props = SharedProps::new()
+///     .value("appName", "My App")
+///     .prop("auth.csrfToken", |request| {
+///         request.headers().get_one("X-CSRF").map(ToOwned::to_owned)
+///     });
+/// ```
+#[derive(Clone, Default)]
+pub struct SharedProps {
+    providers: Vec<(String, SharedPropProvider)>,
+}
+
+impl SharedProps {
+    /// Creates an empty shared prop registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a fixed serializable shared prop value.
+    pub fn value<K, T>(self, key: K, value: T) -> Self
+    where
+        K: Into<String>,
+        T: Clone + Send + Sync + Serialize + 'static,
+    {
+        self.prop(key, move |_request| value.clone())
+    }
+
+    /// Registers a request-aware shared prop provider.
+    ///
+    /// The provider should return an owned serializable value. For request
+    /// data such as headers or cookies, clone the value before returning it.
+    pub fn prop<K, F, T>(mut self, key: K, provider: F) -> Self
+    where
+        K: Into<String>,
+        F: for<'request, 'rocket> Fn(&'request Request<'rocket>) -> T + Send + Sync + 'static,
+        T: Serialize,
+    {
+        let provider =
+            Arc::new(move |request: &Request<'_>| serde_json::to_value(provider(request)));
+
+        self.providers.push((key.into(), provider));
+        self
+    }
+
+    /// Returns `true` when no shared props have been registered.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
+    fn resolve(&self, request: &Request<'_>) -> Result<Vec<(String, Value)>, serde_json::Error> {
+        self.providers
+            .iter()
+            .map(|(key, provider)| provider(request).map(|value| (key.clone(), value)))
+            .collect()
     }
 }
 
@@ -132,9 +210,17 @@ impl<'r, 'o: 'r, R: Serialize> Responder<'r, 'o> for Inertia<R> {
         } else {
             request_context(request).without_partial_reload()
         };
-        let inertia_response = self
+        let mut inertia_response = self
             .into_page(url, version, &context)
             .map_err(|_e| http::Status::InternalServerError)?;
+
+        if let Some(shared_props) = request.rocket().state::<SharedProps>() {
+            inertia_response = inertia_response.with_shared_props(
+                shared_props
+                    .resolve(request)
+                    .map_err(|_e| http::Status::InternalServerError)?,
+            );
+        }
 
         if context.is_inertia() {
             Response::build()
@@ -335,6 +421,11 @@ mod tests {
         Inertia::response("foo", Props { n: 42 })
     }
 
+    #[get("/empty")]
+    fn empty() -> Inertia<()> {
+        Inertia::response("empty", ())
+    }
+
     #[get("/url")]
     fn url_override() -> Inertia<Props> {
         Inertia::response("foo", Props { n: 42 }).with_url("/custom-url")
@@ -468,6 +559,7 @@ mod tests {
                 "/",
                 routes![
                     foo,
+                    empty,
                     url_override,
                     unsafe_props,
                     advanced,
@@ -488,6 +580,18 @@ mod tests {
             .attach(VersionFairing::new(CURRENT_VERSION, |request, ctx| {
                 serde_json::to_string(ctx).unwrap().respond_to(request)
             }))
+    }
+
+    fn rocket_with_shared_props() -> rocket::Rocket<rocket::Build> {
+        rocket().manage(
+            SharedProps::new()
+                .value("appName", "Demo")
+                .value("n", 99)
+                .value("auth.user", serde_json::json!({ "name": "Ada" }))
+                .prop("csrfToken", |request| {
+                    request.headers().get_one("X-CSRF").map(ToOwned::to_owned)
+                }),
+        )
     }
 
     fn rocket_without_fairing() -> rocket::Rocket<rocket::Build> {
@@ -605,6 +709,90 @@ mod tests {
         );
         assert_eq!(page["props"]["users"], serde_json::json!(["Ada", "Grace"]));
         assert!(page["props"].get("stats").is_none());
+    }
+
+    #[test]
+    fn shared_props_are_merged_into_html_responses() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/foo")
+            .header(Header::new("X-CSRF", "token-html"))
+            .dispatch();
+        let body = resp.into_string().unwrap();
+        let ctx: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let data_page = ctx["data_page"].as_str().unwrap();
+        let page: serde_json::Value = serde_json::from_str(data_page).unwrap();
+
+        assert_eq!(page["props"]["appName"], "Demo");
+        assert_eq!(page["props"]["auth"]["user"]["name"], "Ada");
+        assert_eq!(page["props"]["csrfToken"], "token-html");
+        assert_eq!(page["props"]["n"], 42);
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["appName", "auth", "csrfToken"])
+        );
+    }
+
+    #[test]
+    fn shared_props_are_merged_into_json_responses() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/foo")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .header(Header::new("X-CSRF", "token-json"))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(page["props"]["appName"], "Demo");
+        assert_eq!(page["props"]["auth"]["user"]["name"], "Ada");
+        assert_eq!(page["props"]["csrfToken"], "token-json");
+        assert_eq!(page["props"]["n"], 42);
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["appName", "auth", "csrfToken"])
+        );
+    }
+
+    #[test]
+    fn shared_props_turn_empty_props_into_an_object() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/empty")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(
+            page["props"],
+            serde_json::json!({
+                "errors": {},
+                "appName": "Demo",
+                "n": 99,
+                "auth": {
+                    "user": {
+                        "name": "Ada"
+                    }
+                },
+                "csrfToken": null
+            })
+        );
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["appName", "n", "auth", "csrfToken"])
+        );
     }
 
     #[test]
@@ -813,6 +1001,36 @@ mod tests {
                 "stats": 42,
                 "users": ["Ada", "Grace"]
             })
+        );
+    }
+
+    #[test]
+    fn rocket_partial_reload_includes_shared_props() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/advanced")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .header(Header::new(X_INERTIA_PARTIAL_COMPONENT, "advanced"))
+            .header(Header::new(X_INERTIA_PARTIAL_DATA, "stats"))
+            .header(Header::new("X-CSRF", "token-partial"))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(page["props"]["stats"], 42);
+        assert_eq!(page["props"]["users"], serde_json::json!(["Ada", "Grace"]));
+        assert_eq!(page["props"]["appName"], "Demo");
+        assert_eq!(page["props"]["auth"]["user"]["name"], "Ada");
+        assert_eq!(page["props"]["csrfToken"], "token-partial");
+        assert_eq!(page["props"]["n"], 99);
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["users", "appName", "n", "auth", "csrfToken"])
         );
     }
 

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -421,6 +421,20 @@ mod tests {
         Inertia::response("foo", Props { n: 42 })
     }
 
+    #[get("/route-auth")]
+    fn route_auth() -> Inertia<serde_json::Value> {
+        Inertia::response(
+            "route-auth",
+            serde_json::json!({
+                "auth": {
+                    "user": {
+                        "name": "Route"
+                    }
+                }
+            }),
+        )
+    }
+
     #[get("/empty")]
     fn empty() -> Inertia<()> {
         Inertia::response("empty", ())
@@ -559,6 +573,7 @@ mod tests {
                 "/",
                 routes![
                     foo,
+                    route_auth,
                     empty,
                     url_override,
                     unsafe_props,
@@ -792,6 +807,31 @@ mod tests {
         assert_eq!(
             page["sharedProps"],
             serde_json::json!(["appName", "n", "auth", "csrfToken"])
+        );
+    }
+
+    #[test]
+    fn shared_dotted_props_do_not_merge_into_route_owned_roots() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/route-auth")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(page["props"]["auth"]["user"]["name"], "Route");
+        assert_eq!(page["props"]["appName"], "Demo");
+        assert_eq!(page["props"]["n"], 99);
+        assert_eq!(page["props"]["csrfToken"], serde_json::Value::Null);
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["appName", "n", "csrfToken"])
         );
     }
 

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -836,6 +836,33 @@ mod tests {
     }
 
     #[test]
+    fn shared_dotted_props_do_not_replace_filtered_route_owned_roots() {
+        let client = Client::tracked(rocket_with_shared_props()).unwrap();
+
+        let resp = client
+            .get("/route-auth")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .header(Header::new(X_INERTIA_PARTIAL_COMPONENT, "route-auth"))
+            .header(Header::new(X_INERTIA_PARTIAL_DATA, "missing"))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert!(page["props"].get("auth").is_none());
+        assert_eq!(page["props"]["appName"], "Demo");
+        assert_eq!(page["props"]["n"], 99);
+        assert_eq!(page["props"]["csrfToken"], serde_json::Value::Null);
+        assert_eq!(
+            page["sharedProps"],
+            serde_json::json!(["appName", "n", "csrfToken"])
+        );
+    }
+
+    #[test]
     fn json_response_includes_query_string() {
         let client = Client::tracked(rocket()).unwrap();
 


### PR DESCRIPTION
## Summary
- add Rocket managed state for shared Inertia props with request-aware providers
- merge shared props into HTML and JSON page responses, including dotted keys
- document the API and partial-reload behavior

## Validation
- cargo fmt --check
- cargo test --all-features
- cargo clippy --all-features --all-targets -- -D warnings
- cargo check --no-default-features
- RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
- RUSTDOCFLAGS="-D warnings" cargo doc --no-default-features --no-deps
- cargo test --manifest-path examples/Cargo.toml
- npm run build in examples/rocket-svelte/svelte-app
- agent-browser smoke against the Rocket example