### PR TITLE
Document protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+
+- Rocket 0.5.1, Svelte 5, and Vite example updates.
+- Public Inertia protocol header constants and `RequestContext` parsing.
+- Inertia v3 page-object metadata for history flags, merge props, deferred props, once props, shared props, and scroll props.
+- Partial reload filtering for matching Inertia components.
+- Asset version handling for successful page responses and stale Inertia visits.
+- `VersionFairing::dynamic` for request-time asset version values.
+- `InertiaHeaders` Rocket request guard.
+- `Inertia::location` for external Inertia redirects.
+- `Inertia::redirect` for method-aware application redirects.
+- Rocket `SharedProps` managed state for common page props.
+- README protocol support matrix.
+
+### Changed
+
+- Preserved query strings in generated page object URLs.
+- Added `Vary: X-Inertia` to responses that vary between HTML and JSON.
+- Modernized GitHub Actions CI and declared an MSRV of Rust 1.88.
+- Expanded crate and public API rustdoc.
+
+### Fixed
+
+- Escaped serialized page JSON for safe embedding in HTML script contexts.
+- Kept shared dotted props from merging into route-owned prop roots.
+- Preserved route-owned prop roots across partial filtering before shared-prop merging.
+- Kept internal route-prop tracking out of `Page` equality.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,33 @@ Inertia lets you build server-driven applications that render client-side pages 
 - Asset version checks with `X-Inertia-Version`.
 - `409 Conflict` responses with `X-Inertia-Location` for stale assets.
 - Inertia v3 page-object metadata and response filtering for partial reloads, merge props, deferred prop keys, once props, history flags, and infinite-scroll metadata.
+- Rocket shared props with request-aware providers.
 
-Shared application state helpers, lazy or async prop resolvers, SSR, and non-Rocket framework integrations are planned but not fully implemented yet.
+Lazy or async prop resolvers, SSR, and non-Rocket framework integrations are planned but not fully implemented yet.
 
 The minimum supported Rust version is 1.88.
+
+## Protocol Support
+
+| Feature | Status | Notes |
+| --- | --- | --- |
+| Initial HTML response | Supported | Rocket renders the application shell through `VersionFairing`. |
+| JSON Inertia response | Supported | Responses include `X-Inertia: true` and `Vary: X-Inertia`. |
+| Asset version conflicts | Supported | Stale Inertia `GET` requests return `409 Conflict` with `X-Inertia-Location`. |
+| Dynamic asset versions | Supported | `VersionFairing::dynamic` reads the current version when page responses or version checks need it. |
+| Query-string URLs | Supported | Page object URLs preserve the request query string. |
+| Public header helpers | Supported | Header constants are available at the crate root and through `inertia_rs::headers`. |
+| Request header parsing | Supported | `RequestContext` is framework-neutral; Rocket exposes `InertiaHeaders`. |
+| Partial reloads | Supported | Matching components honor `X-Inertia-Partial-Data` and `X-Inertia-Partial-Except`. |
+| Merge props | Supported | `mergeProps`, `prependProps`, `deepMergeProps`, `matchPropsOn`, reset handling, and infinite-scroll intent are modeled. |
+| Deferred props | Partial | `deferredProps` metadata is emitted and values are omitted until requested, but prop values are still serialized eagerly. |
+| Lazy or async props | Planned | There is no lazy resolver container yet. |
+| Once props | Supported | `onceProps` metadata and `X-Inertia-Except-Once-Props` filtering are modeled. |
+| Shared props | Supported | Rocket managed state can merge common props into every page response. |
+| External location redirects | Supported | `Inertia::location` maps Inertia visits to `409 Conflict` with `X-Inertia-Location`. |
+| Method-aware redirects | Supported | `Inertia::redirect` returns `303 See Other` for write methods. |
+| SSR | Not supported | No server-side rendering bridge is provided. |
+| Axum | Planned | Framework expansion is deferred until the Rocket integration settles on the protocol core. |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add a README protocol support matrix
- add an unreleased changelog for the revival work
- update status wording for Rocket shared props

## Validation
- cargo fmt --check
- cargo test --all-features
- git diff --check