### PR TITLE
Add sync lazy prop container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Rocket `SharedProps` managed state for common page props.
 - Initial Axum integration with `InertiaRequest`, `VersionLayer`, page response rendering, external locations, and method-aware redirects.
 - Minimal Axum example.
+- `InertiaProps` and `ScopedInertiaProps` for synchronous lazy, optional, deferred, and once prop resolvers.
 - README protocol support matrix.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Inertia lets you build server-driven applications that render client-side pages 
 - Asset version checks with `X-Inertia-Version`.
 - `409 Conflict` responses with `X-Inertia-Location` for stale assets.
 - Inertia v3 page-object metadata and response filtering for partial reloads, merge props, deferred prop keys, once props, history flags, and infinite-scroll metadata.
+- Framework-neutral `InertiaProps` for synchronous lazy, optional, deferred, and once prop resolvers.
 - Rocket shared props with request-aware providers.
 - Axum request extraction, response helpers, and asset-version middleware.
 
-Lazy or async prop resolvers, SSR, and full shared-prop support outside Rocket are planned but not fully implemented yet.
+Async prop resolvers, SSR, and full shared-prop support outside Rocket are planned but not fully implemented yet.
 
 The minimum supported Rust version is 1.88.
 
@@ -37,8 +38,8 @@ The minimum supported Rust version is 1.88.
 | Request header parsing | Supported | `RequestContext` is framework-neutral; Rocket exposes `InertiaHeaders`. |
 | Partial reloads | Supported | Matching components honor `X-Inertia-Partial-Data` and `X-Inertia-Partial-Except`. |
 | Merge props | Supported | `mergeProps`, `prependProps`, `deepMergeProps`, `matchPropsOn`, reset handling, and infinite-scroll intent are modeled. |
-| Deferred props | Partial | `deferredProps` metadata is emitted and values are omitted until requested, but prop values are still serialized eagerly. |
-| Lazy or async props | Planned | There is no lazy resolver container yet. |
+| Deferred props | Partial | `InertiaProps::defer` emits `deferredProps` metadata and resolves synchronous values only when requested. Async deferred resolvers are planned. |
+| Lazy or async props | Partial | `InertiaProps` supports synchronous lazy, optional, always, deferred, and once props. Async resolvers are planned. |
 | Once props | Supported | `onceProps` metadata and `X-Inertia-Except-Once-Props` filtering are modeled. |
 | Shared props | Supported | Rocket managed state can merge common props into every page response. |
 | External location redirects | Supported | `Inertia::location` maps Inertia visits to `409 Conflict` with `X-Inertia-Location`. |
@@ -185,7 +186,7 @@ The simple API remains the shortest path for standard pages:
 Inertia::response("Users/Index", props)
 ```
 
-For v3 page metadata, chain explicit helpers on the response or use the `Inertia::page(...).props(...)` builder. Deferred props are listed in `deferredProps` and omitted until an Inertia partial reload explicitly requests them; this crate does not yet provide lazy async prop resolvers. `share()` marks `sharedProps` metadata, while the Rocket integration can register shared application state as shown below.
+For v3 page metadata, chain explicit helpers on the response or use the `Inertia::page(...).props(...)` builder. Deferred props are listed in `deferredProps` and omitted until an Inertia partial reload explicitly requests them. When props are ordinary serializable values, they are serialized before filtering. Use `InertiaProps` when expensive synchronous values should only be resolved after the request headers determine they are needed. `share()` marks `sharedProps` metadata, while the Rocket integration can register shared application state as shown below.
 
 ```rust
 Inertia::response("Users/Index", props)
@@ -202,6 +203,22 @@ Inertia::page("Users/Index")
     .defer("stats")
     .props(props)
 ```
+
+```rust
+use inertia_rs::{Inertia, InertiaProps};
+
+let props = InertiaProps::new()
+    .value("user", user)
+    .lazy("companies", || load_companies())
+    .optional("auditTrail", || load_audit_trail())
+    .defer("analytics", || load_analytics())
+    .once("plans", || load_plans());
+
+Inertia::response("Users/Index", props)
+```
+
+For immediate rendering paths that borrow local values, use
+`ScopedInertiaProps`.
 
 The root crate also exposes framework-neutral protocol types:
 

--- a/examples/axum-minimal/Cargo.toml
+++ b/examples/axum-minimal/Cargo.toml
@@ -8,5 +8,4 @@ publish = false
 [dependencies]
 axum = "0.8"
 inertia_rs = { path = "../..", default-features = false, features = ["axum"] }
-serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }

--- a/examples/axum-minimal/README.md
+++ b/examples/axum-minimal/README.md
@@ -17,5 +17,15 @@ curl -H 'X-Inertia: true' -H 'X-Inertia-Version: asset-version-1' \
   http://127.0.0.1:3001/hello
 ```
 
+Deferred and optional props are resolved when a matching partial reload asks
+for them:
+
+```sh
+curl -H 'X-Inertia: true' -H 'X-Inertia-Version: asset-version-1' \
+  -H 'X-Inertia-Partial-Component: Hello' \
+  -H 'X-Inertia-Partial-Data: stats,debug' \
+  http://127.0.0.1:3001/hello
+```
+
 A stale or missing Inertia version returns `409 Conflict` with
 `X-Inertia-Location`.

--- a/examples/axum-minimal/src/main.rs
+++ b/examples/axum-minimal/src/main.rs
@@ -2,20 +2,16 @@ use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use inertia_rs::axum::{InertiaError, InertiaRequest, VersionLayer};
-use inertia_rs::Inertia;
-
-#[derive(serde::Serialize)]
-struct Hello {
-    name: String,
-}
+use inertia_rs::{Inertia, InertiaProps};
 
 async fn hello(request: InertiaRequest) -> Result<Response, InertiaError> {
     request.render(
         Inertia::response(
             "Hello",
-            Hello {
-                name: "world".into(),
-            },
+            InertiaProps::new()
+                .value("name", "world")
+                .defer("stats", || 1)
+                .optional("debug", || "partial"),
         ),
         |context| {
             Html(format!(

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -1,8 +1,8 @@
 //! Axum integration for `inertia_rs`.
 
 use super::{
-    html_response_context, Inertia, Location, Redirect, RequestContext, VARY, X_INERTIA,
-    X_INERTIA_LOCATION,
+    html_response_context, Inertia, IntoPageProps, Location, Redirect, RequestContext, VARY,
+    X_INERTIA, X_INERTIA_LOCATION,
 };
 use ::axum::extract::{FromRequestParts, OriginalUri};
 use ::axum::http::header::{InvalidHeaderValue, LOCATION};
@@ -12,7 +12,6 @@ use ::axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode};
 use ::axum::response::{IntoResponse, Response};
 use ::axum::Json;
 use fluent_uri::{ParseError, UriRef};
-use serde::Serialize;
 use std::convert::Infallible;
 use std::error::Error;
 use std::fmt;
@@ -215,7 +214,7 @@ impl InertiaRequest {
         html_response: F,
     ) -> Result<Response, InertiaError>
     where
-        T: Serialize,
+        T: IntoPageProps,
         F: FnOnce(HtmlResponseContext) -> R,
         R: IntoResponse,
     {
@@ -389,8 +388,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        X_INERTIA_EXCEPT_ONCE_PROPS, X_INERTIA_PARTIAL_COMPONENT, X_INERTIA_PARTIAL_DATA,
-        X_INERTIA_VERSION,
+        InertiaProps, X_INERTIA_EXCEPT_ONCE_PROPS, X_INERTIA_PARTIAL_COMPONENT,
+        X_INERTIA_PARTIAL_DATA, X_INERTIA_VERSION,
     };
     use ::axum::body::Body;
     use ::axum::http::header::CONTENT_TYPE;
@@ -398,6 +397,7 @@ mod tests {
     use ::axum::response::Html;
     use ::axum::routing::get;
     use ::axum::Router;
+    use serde::Serialize;
     use serde_json::json;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
@@ -470,6 +470,19 @@ mod tests {
         )
     }
 
+    async fn lazy_page(request: InertiaRequest) -> Result<Response, InertiaError> {
+        request.render(
+            Inertia::response(
+                "lazy",
+                InertiaProps::new()
+                    .value("users", json!(["Ada", "Grace"]))
+                    .defer("stats", || 7)
+                    .optional("audit", || json!(["created"])),
+            ),
+            |context| Html(context.data_page().to_owned()),
+        )
+    }
+
     async fn unsafe_page(request: InertiaRequest) -> Result<Response, InertiaError> {
         request.render(
             Inertia::response(
@@ -516,6 +529,7 @@ mod tests {
             .route("/foo", get(page).post(page))
             .route("/custom-url", get(custom_url))
             .route("/builder", get(builder_page))
+            .route("/lazy", get(lazy_page))
             .route("/unsafe", get(unsafe_page))
             .route("/external", get(external).post(external))
             .route("/relative-external", get(relative_location))
@@ -738,6 +752,53 @@ mod tests {
 
         assert_eq!(page["component"], "builder");
         assert_eq!(page["mergeProps"], json!(["notifications"]));
+    }
+
+    #[tokio::test]
+    async fn render_supports_lazy_props() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/lazy")
+                    .header(X_INERTIA, "true")
+                    .header(X_INERTIA_VERSION, "1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let page = body_json(response).await;
+
+        assert_eq!(page["props"]["users"], json!(["Ada", "Grace"]));
+        assert!(page["props"].get("stats").is_none());
+        assert!(page["props"].get("audit").is_none());
+        assert_eq!(page["deferredProps"], json!({ "default": ["stats"] }));
+
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/lazy")
+                    .header(X_INERTIA, "true")
+                    .header(X_INERTIA_VERSION, "1")
+                    .header(X_INERTIA_PARTIAL_COMPONENT, "lazy")
+                    .header(X_INERTIA_PARTIAL_DATA, "stats,audit")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let page = body_json(response).await;
+
+        assert_eq!(page["props"]["stats"], 7);
+        assert_eq!(page["props"]["audit"], json!(["created"]));
+        assert!(page["props"].get("users").is_none());
+        assert!(page.get("deferredProps").is_none());
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,12 @@ fn dedup_strings(values: &mut Vec<String>) {
     values.retain(|value| seen.insert(value.clone()));
 }
 
+fn push_unique_string(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
 fn parse_header_list(value: Option<&str>) -> Vec<String> {
     value
         .into_iter()
@@ -421,6 +427,30 @@ fn insert_shared_prop_path(props: &mut Map<String, Value>, path: &[&str], value:
 
 fn string_set(values: &[String]) -> BTreeSet<&str> {
     values.iter().map(String::as_str).collect()
+}
+
+fn partial_reload_includes_prop(context: &RequestContext, component: &str, prop: &str) -> bool {
+    if !context.partial_reload_matches(component) {
+        return true;
+    }
+
+    let partial_excluded = string_set(context.partial_except());
+
+    if !partial_excluded.is_empty() {
+        return !partial_excluded.contains(prop);
+    }
+
+    let partial_requested = string_set(context.partial_data());
+
+    partial_requested.is_empty() || partial_requested.contains(prop)
+}
+
+fn partial_reload_explicitly_requests_prop(
+    context: &RequestContext,
+    component: &str,
+    prop: &str,
+) -> bool {
+    context.partial_reload_matches(component) && string_set(context.partial_data()).contains(prop)
 }
 
 /// Additional Inertia v3 page-object metadata.
@@ -657,11 +687,22 @@ impl PageMetadata {
 
         let included_props = props.keys().map(String::as_str).collect::<BTreeSet<_>>();
         let partial_matches = context.partial_reload_matches(component);
+        let once_excluded_props = self.once_props_excluded_by(context);
         let reset_props = if partial_matches {
             string_set(context.reset())
         } else {
             BTreeSet::new()
         };
+
+        for deferred_props in metadata.deferred_props.values_mut() {
+            deferred_props.retain(|prop| {
+                !prop_is_in_set(prop, &included_props)
+                    && !once_excluded_props.contains(prop.as_str())
+            });
+        }
+        metadata
+            .deferred_props
+            .retain(|_group, props| !props.is_empty());
 
         metadata.merge_props.retain(|prop| {
             prop_is_in_set(prop, &included_props) && !prop_matches_reset(prop, &reset_props)
@@ -742,6 +783,354 @@ impl OnceProp {
     /// Returns the optional expiration timestamp in milliseconds.
     pub fn expiration(&self) -> Option<u64> {
         self.expires_at
+    }
+}
+
+/// Converts a value into a filtered Inertia props object.
+///
+/// Most callers use ordinary serializable structs or maps. [`InertiaProps`]
+/// implements this trait for route-local lazy, optional, and deferred
+/// synchronous resolvers.
+pub trait IntoPageProps {
+    /// Builds the concrete JSON props object, response metadata, and route
+    /// prop roots for shared-prop collision handling.
+    fn into_page_props(
+        self,
+        component: &str,
+        request: &RequestContext,
+        metadata: PageMetadata,
+    ) -> Result<(Value, PageMetadata, Vec<String>), serde_json::Error>;
+}
+
+impl<T: Serialize> IntoPageProps for T {
+    fn into_page_props(
+        self,
+        component: &str,
+        request: &RequestContext,
+        metadata: PageMetadata,
+    ) -> Result<(Value, PageMetadata, Vec<String>), serde_json::Error> {
+        let mut props = serde_json::to_value(self)?;
+        let route_props = props
+            .as_object()
+            .map(|props| props.keys().cloned().collect())
+            .unwrap_or_default();
+
+        request.filter_props(component, &mut props, &metadata);
+        let metadata = metadata.for_response(request, component, props.as_object());
+
+        Ok((props, metadata, route_props))
+    }
+}
+
+trait PropResolver {
+    fn resolve(self: Box<Self>) -> Result<Value, serde_json::Error>;
+}
+
+impl<F, T> PropResolver for F
+where
+    F: FnOnce() -> T,
+    T: Serialize,
+{
+    fn resolve(self: Box<Self>) -> Result<Value, serde_json::Error> {
+        serde_json::to_value(self())
+    }
+}
+
+enum PropMode {
+    Standard,
+    Optional,
+    Always,
+    Deferred { group: String },
+}
+
+struct PropEntry<'props> {
+    key: String,
+    mode: PropMode,
+    once: Option<(String, OnceProp)>,
+    resolver: Box<dyn PropResolver + 'props>,
+}
+
+impl PropEntry<'_> {
+    fn apply_metadata(&self, metadata: &mut PageMetadata) {
+        match &self.mode {
+            PropMode::Always => push_unique_string(&mut metadata.always_props, self.key.clone()),
+            PropMode::Deferred { group } => {
+                let props = metadata.deferred_props.entry(group.clone()).or_default();
+                push_unique_string(props, self.key.clone());
+            }
+            PropMode::Standard | PropMode::Optional => {}
+        }
+
+        if let Some((key, once)) = &self.once {
+            metadata.once_props.insert(key.clone(), once.clone());
+        }
+    }
+
+    fn should_resolve(
+        &self,
+        component: &str,
+        request: &RequestContext,
+        metadata: &PageMetadata,
+    ) -> bool {
+        let key = self.key.as_str();
+
+        if key == "errors" {
+            return true;
+        }
+
+        let always_props = string_set(metadata.always_props());
+
+        if always_props.contains(key) {
+            return true;
+        }
+
+        let explicitly_requested = partial_reload_explicitly_requests_prop(request, component, key);
+        let deferred_props = metadata.deferred_prop_names();
+
+        if deferred_props.contains(key) && !explicitly_requested {
+            return false;
+        }
+
+        let once_excluded_props = metadata.once_props_excluded_by(request);
+
+        if once_excluded_props.contains(key) && !explicitly_requested {
+            return false;
+        }
+
+        let included_by_partial_reload = partial_reload_includes_prop(request, component, key);
+
+        if matches!(self.mode, PropMode::Optional) {
+            return explicitly_requested && included_by_partial_reload;
+        }
+
+        included_by_partial_reload
+    }
+}
+
+/// Route-local props with synchronous lazy evaluation.
+///
+/// Use this when expensive props should only be serialized once an Inertia
+/// request actually needs them. Standard lazy props are included on full
+/// visits and matching partial reloads unless excluded. Optional props are
+/// only included when explicitly requested by `X-Inertia-Partial-Data`.
+/// Deferred props emit `deferredProps` metadata and are resolved when a later
+/// partial reload requests them.
+pub type InertiaProps = ScopedInertiaProps<'static>;
+
+/// Lifetime-aware route-local props with synchronous lazy evaluation.
+///
+/// Use this variant when props are rendered immediately and resolvers need to
+/// borrow data that does not live for the full `'static` lifetime. For owned
+/// route return values, use [`InertiaProps`].
+#[derive(Default)]
+pub struct ScopedInertiaProps<'props> {
+    entries: Vec<PropEntry<'props>>,
+}
+
+impl<'props> ScopedInertiaProps<'props> {
+    /// Creates an empty lazy props container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a standard prop value.
+    ///
+    /// The value is already computed by the caller, but serialization is still
+    /// skipped when partial reload headers omit the prop.
+    pub fn value<P, T>(self, prop: P, value: T) -> Self
+    where
+        P: Into<String>,
+        T: Serialize + 'props,
+    {
+        self.entry(prop, PropMode::Standard, None, move || value)
+    }
+
+    /// Adds a standard lazy prop.
+    ///
+    /// The resolver is called for full visits and for matching partial
+    /// reloads that include the prop.
+    pub fn lazy<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.entry(prop, PropMode::Standard, None, resolver)
+    }
+
+    /// Adds a prop that is only resolved when explicitly requested.
+    pub fn optional<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.entry(prop, PropMode::Optional, None, resolver)
+    }
+
+    /// Adds a prop that is always included, even during partial reloads.
+    pub fn always<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.entry(prop, PropMode::Always, None, resolver)
+    }
+
+    /// Adds a deferred prop in the default group.
+    pub fn defer<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.defer_group("default", prop, resolver)
+    }
+
+    /// Adds a deferred prop in `group`.
+    pub fn defer_group<G, P, F, T>(self, group: G, prop: P, resolver: F) -> Self
+    where
+        G: Into<String>,
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.entry(
+            prop,
+            PropMode::Deferred {
+                group: group.into(),
+            },
+            None,
+            resolver,
+        )
+    }
+
+    /// Adds a standard lazy prop with once-prop metadata.
+    pub fn once<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        let prop = prop.into();
+        let once = OnceProp::new(prop.clone());
+        self.entry(
+            prop.clone(),
+            PropMode::Standard,
+            Some((prop, once)),
+            resolver,
+        )
+    }
+
+    /// Adds a standard lazy prop with a custom once key.
+    pub fn once_with_key<K, F, T>(self, key: K, once: OnceProp, resolver: F) -> Self
+    where
+        K: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        let prop = once.prop().to_owned();
+        self.entry(prop, PropMode::Standard, Some((key.into(), once)), resolver)
+    }
+
+    /// Adds an optional prop with once-prop metadata.
+    pub fn optional_once<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        let prop = prop.into();
+        let once = OnceProp::new(prop.clone());
+        self.entry(
+            prop.clone(),
+            PropMode::Optional,
+            Some((prop, once)),
+            resolver,
+        )
+    }
+
+    /// Adds a deferred prop with once-prop metadata in the default group.
+    pub fn defer_once<P, F, T>(self, prop: P, resolver: F) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.defer_group_once("default", prop, resolver)
+    }
+
+    /// Adds a deferred prop with once-prop metadata in `group`.
+    pub fn defer_group_once<G, P, F, T>(self, group: G, prop: P, resolver: F) -> Self
+    where
+        G: Into<String>,
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        let prop = prop.into();
+        let once = OnceProp::new(prop.clone());
+        self.entry(
+            prop.clone(),
+            PropMode::Deferred {
+                group: group.into(),
+            },
+            Some((prop, once)),
+            resolver,
+        )
+    }
+
+    fn entry<P, F, T>(
+        mut self,
+        prop: P,
+        mode: PropMode,
+        once: Option<(String, OnceProp)>,
+        resolver: F,
+    ) -> Self
+    where
+        P: Into<String>,
+        F: FnOnce() -> T + 'props,
+        T: Serialize,
+    {
+        self.entries.push(PropEntry {
+            key: prop.into(),
+            mode,
+            once,
+            resolver: Box::new(resolver),
+        });
+        self
+    }
+}
+
+impl<'props> IntoPageProps for ScopedInertiaProps<'props> {
+    fn into_page_props(
+        self,
+        component: &str,
+        request: &RequestContext,
+        mut metadata: PageMetadata,
+    ) -> Result<(Value, PageMetadata, Vec<String>), serde_json::Error> {
+        for entry in &self.entries {
+            entry.apply_metadata(&mut metadata);
+        }
+
+        let mut props = Map::new();
+        let mut route_props = Vec::new();
+
+        for entry in self.entries {
+            let route_root = prop_root(&entry.key).to_owned();
+            push_unique_string(&mut route_props, route_root);
+
+            if entry.should_resolve(component, request, &metadata) {
+                let key = entry.key;
+                props.insert(key, entry.resolver.resolve()?);
+            }
+        }
+
+        ensure_errors_prop(&mut props);
+        let metadata = metadata.for_response(request, component, Some(&props));
+
+        Ok((Value::Object(props), metadata, route_props))
     }
 }
 
@@ -1297,7 +1686,7 @@ impl<T> Inertia<T> {
     }
 }
 
-impl<T: Serialize> Inertia<T> {
+impl<T: IntoPageProps> Inertia<T> {
     /// Builds a concrete Inertia page object.
     ///
     /// Framework integrations pass the resolved request URL, asset version,
@@ -1310,15 +1699,9 @@ impl<T: Serialize> Inertia<T> {
         request: &RequestContext,
     ) -> Result<Page<Value>, serde_json::Error> {
         let component = self.component;
-        let metadata = self.metadata;
-        let mut props = serde_json::to_value(self.props)?;
-        let route_props = props
-            .as_object()
-            .map(|props| props.keys().cloned().collect())
-            .unwrap_or_default();
-
-        request.filter_props(&component, &mut props, &metadata);
-        let metadata = metadata.for_response(request, &component, props.as_object());
+        let (props, metadata, route_props) =
+            self.props
+                .into_page_props(&component, request, self.metadata)?;
 
         let mut page = Page::from_parts(component, props, url, version, metadata);
         page.route_props = RouteProps(route_props);
@@ -1331,7 +1714,9 @@ impl<T: Serialize> Inertia<T> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::cell::Cell;
     use std::collections::HashMap;
+    use std::rc::Rc;
 
     fn request_context_from(headers: &[(&str, &str)]) -> RequestContext {
         let headers = headers.iter().copied().collect::<HashMap<_, _>>();
@@ -1642,6 +2027,357 @@ mod tests {
             value["onceProps"]["billing"],
             json!({ "prop": "plans", "expiresAt": 123 })
         );
+    }
+
+    #[test]
+    fn lazy_props_are_only_resolved_when_included() {
+        let request = request_context_from(&[]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new()
+                .value("user", json!({ "name": "Ada" }))
+                .lazy("stats", {
+                    let calls = Rc::clone(&calls);
+                    move || {
+                        calls.set(calls.get() + 1);
+                        json!({ "views": 10 })
+                    }
+                }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["stats"]["views"], 10);
+
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Dashboard"),
+            (X_INERTIA_PARTIAL_DATA, "user"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new()
+                .value("user", json!({ "name": "Ada" }))
+                .lazy("stats", {
+                    let calls = Rc::clone(&calls);
+                    move || {
+                        calls.set(calls.get() + 1);
+                        json!({ "views": 10 })
+                    }
+                }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert_eq!(value["props"]["user"]["name"], "Ada");
+        assert!(value["props"].get("stats").is_none());
+    }
+
+    #[test]
+    fn lazy_props_can_borrow_values_for_immediate_rendering() {
+        let request = request_context_from(&[]);
+        let name = String::from("Ada");
+        let response = Inertia::response(
+            "Profile",
+            ScopedInertiaProps::new()
+                .value("name", &name)
+                .lazy("upperName", || name.to_uppercase()),
+        )
+        .into_page("/profile", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(value["props"]["name"], "Ada");
+        assert_eq!(value["props"]["upperName"], "ADA");
+    }
+
+    #[test]
+    fn optional_props_resolve_only_when_explicitly_requested() {
+        let request = request_context_from(&[]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().optional("audit", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!(["created"])
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert!(value["props"].get("audit").is_none());
+
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Dashboard"),
+            (X_INERTIA_PARTIAL_DATA, "audit"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().optional("audit", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!(["created"])
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["audit"], json!(["created"]));
+    }
+
+    #[test]
+    fn optional_props_respect_partial_except_precedence() {
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Dashboard"),
+            (X_INERTIA_PARTIAL_DATA, "audit"),
+            (X_INERTIA_PARTIAL_EXCEPT, "audit"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().optional("audit", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!(["created"])
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert!(value["props"].get("audit").is_none());
+    }
+
+    #[test]
+    fn lazy_errors_are_preserved_during_partial_reloads() {
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Form"),
+            (X_INERTIA_PARTIAL_DATA, "user"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Form",
+            InertiaProps::new()
+                .value("user", json!({ "name": "Ada" }))
+                .lazy("errors", {
+                    let calls = Rc::clone(&calls);
+                    move || {
+                        calls.set(calls.get() + 1);
+                        json!({ "name": "Required" })
+                    }
+                })
+                .lazy("stats", || 10),
+        )
+        .into_page("/form", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["user"]["name"], "Ada");
+        assert_eq!(value["props"]["errors"]["name"], "Required");
+        assert!(value["props"].get("stats").is_none());
+    }
+
+    #[test]
+    fn deferred_props_emit_metadata_and_resolve_only_when_requested() {
+        let request = request_context_from(&[]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().defer_group("metrics", "analytics", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!({ "views": 10 })
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert!(value["props"].get("analytics").is_none());
+        assert_eq!(value["deferredProps"], json!({ "metrics": ["analytics"] }));
+
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Dashboard"),
+            (X_INERTIA_PARTIAL_DATA, "analytics"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().defer_group("metrics", "analytics", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!({ "views": 10 })
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["analytics"]["views"], 10);
+        assert!(value.get("deferredProps").is_none());
+    }
+
+    #[test]
+    fn deferred_once_props_already_loaded_by_client_are_not_advertised() {
+        let request =
+            request_context_from(&[(X_INERTIA, "true"), (X_INERTIA_EXCEPT_ONCE_PROPS, "stats")]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().defer_once("stats", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    10
+                }
+            }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert!(value["props"].get("stats").is_none());
+        assert!(value.get("deferredProps").is_none());
+        assert_eq!(
+            value["onceProps"]["stats"],
+            json!({ "prop": "stats", "expiresAt": null })
+        );
+    }
+
+    #[test]
+    fn always_lazy_props_survive_partial_reload_filtering() {
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Dashboard"),
+            (X_INERTIA_PARTIAL_DATA, "users"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new()
+                .value("users", json!(["Ada"]))
+                .always("auth", {
+                    let calls = Rc::clone(&calls);
+                    move || {
+                        calls.set(calls.get() + 1);
+                        json!({ "user": { "name": "Ada" } })
+                    }
+                }),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["users"], json!(["Ada"]));
+        assert_eq!(value["props"]["auth"]["user"]["name"], "Ada");
+    }
+
+    #[test]
+    fn once_lazy_props_are_not_resolved_when_client_already_has_them() {
+        let request =
+            request_context_from(&[(X_INERTIA, "true"), (X_INERTIA_EXCEPT_ONCE_PROPS, "plans")]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Billing",
+            InertiaProps::new().once("plans", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!(["basic"])
+                }
+            }),
+        )
+        .into_page("/billing", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert!(value["props"].get("plans").is_none());
+        assert_eq!(
+            value["onceProps"]["plans"],
+            json!({ "prop": "plans", "expiresAt": null })
+        );
+
+        let request = request_context_from(&[
+            (X_INERTIA, "true"),
+            (X_INERTIA_PARTIAL_COMPONENT, "Billing"),
+            (X_INERTIA_PARTIAL_DATA, "plans"),
+            (X_INERTIA_EXCEPT_ONCE_PROPS, "plans"),
+        ]);
+        let calls = Rc::new(Cell::new(0));
+        let response = Inertia::response(
+            "Billing",
+            InertiaProps::new().once("plans", {
+                let calls = Rc::clone(&calls);
+                move || {
+                    calls.set(calls.get() + 1);
+                    json!(["basic"])
+                }
+            }),
+        )
+        .into_page("/billing", Some("version-1".into()), &request)
+        .unwrap();
+        let value = serde_json::to_value(response).unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value["props"]["plans"], json!(["basic"]));
+    }
+
+    #[test]
+    fn lazy_route_prop_roots_block_shared_props_even_when_omitted() {
+        let request = request_context_from(&[]);
+        let response = Inertia::response(
+            "Dashboard",
+            InertiaProps::new().optional("auth", || json!({ "user": { "name": "Route" } })),
+        )
+        .into_page("/dashboard", Some("version-1".into()), &request)
+        .unwrap()
+        .with_shared_props(vec![
+            (
+                "auth.user",
+                json!({
+                    "name": "Shared"
+                }),
+            ),
+            ("appName", json!("Demo")),
+        ]);
+        let value = serde_json::to_value(response).unwrap();
+
+        assert!(value["props"].get("auth").is_none());
+        assert_eq!(value["props"]["appName"], "Demo");
+        assert_eq!(value["sharedProps"], json!(["appName"]));
     }
 
     #[test]

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -3,8 +3,8 @@
 //! Rocket integration for `inertia_rs`.
 
 use super::{
-    html_response_context, Inertia, Location, Redirect, RequestContext, VARY, X_INERTIA,
-    X_INERTIA_LOCATION,
+    html_response_context, Inertia, IntoPageProps, Location, Redirect, RequestContext, VARY,
+    X_INERTIA, X_INERTIA_LOCATION,
 };
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::{self, uri::Reference, Method};
@@ -167,7 +167,7 @@ fn is_write_method(method: Method) -> bool {
     )
 }
 
-impl<'r, 'o: 'r, R: Serialize> Responder<'r, 'o> for Inertia<R> {
+impl<'r, 'o: 'r, R: IntoPageProps> Responder<'r, 'o> for Inertia<R> {
     #[inline(always)]
     fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
         let url = self
@@ -389,9 +389,9 @@ impl Fairing for VersionFairing<'static> {
 mod tests {
     use super::*;
     use crate::{
-        ScrollProps, X_INERTIA_EXCEPT_ONCE_PROPS, X_INERTIA_INFINITE_SCROLL_MERGE_INTENT,
-        X_INERTIA_PARTIAL_COMPONENT, X_INERTIA_PARTIAL_DATA, X_INERTIA_PARTIAL_EXCEPT,
-        X_INERTIA_RESET, X_INERTIA_VERSION,
+        InertiaProps, ScrollProps, X_INERTIA_EXCEPT_ONCE_PROPS,
+        X_INERTIA_INFINITE_SCROLL_MERGE_INTENT, X_INERTIA_PARTIAL_COMPONENT,
+        X_INERTIA_PARTIAL_DATA, X_INERTIA_PARTIAL_EXCEPT, X_INERTIA_RESET, X_INERTIA_VERSION,
     };
     use rocket::{
         delete,
@@ -481,6 +481,17 @@ mod tests {
         .defer("stats")
         .once("plans")
         .share("users")
+    }
+
+    #[get("/lazy")]
+    fn lazy() -> Inertia<InertiaProps> {
+        Inertia::response(
+            "lazy",
+            InertiaProps::new()
+                .value("users", serde_json::json!(["Ada", "Grace"]))
+                .defer("stats", || 42)
+                .optional("audit", || serde_json::json!(["created"])),
+        )
     }
 
     #[rocket::post("/write")]
@@ -584,6 +595,7 @@ mod tests {
                     url_override,
                     unsafe_props,
                     advanced,
+                    lazy,
                     write,
                     scrolling,
                     external,
@@ -1092,6 +1104,48 @@ mod tests {
         assert_eq!(page["props"]["errors"], serde_json::json!({}));
         assert_eq!(page["props"]["users"], serde_json::json!(["Ada", "Grace"]));
         assert!(page["props"].get("stats").is_none());
+    }
+
+    #[test]
+    fn rocket_json_response_supports_lazy_props() {
+        let client = Client::tracked(rocket()).unwrap();
+
+        let resp = client
+            .get("/lazy")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(page["props"]["users"], serde_json::json!(["Ada", "Grace"]));
+        assert!(page["props"].get("stats").is_none());
+        assert!(page["props"].get("audit").is_none());
+        assert_eq!(
+            page["deferredProps"],
+            serde_json::json!({ "default": ["stats"] })
+        );
+
+        let resp = client
+            .get("/lazy")
+            .header(Header::new(X_INERTIA, "true"))
+            .header(Header::new(X_INERTIA_VERSION, CURRENT_VERSION))
+            .header(Header::new(X_INERTIA_PARTIAL_COMPONENT, "lazy"))
+            .header(Header::new(X_INERTIA_PARTIAL_DATA, "stats,audit"))
+            .dispatch();
+
+        assert_eq!(resp.status(), Status::Ok);
+
+        let body = resp.into_string().unwrap();
+        let page: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(page["props"]["stats"], 42);
+        assert_eq!(page["props"]["audit"], serde_json::json!(["created"]));
+        assert!(page["props"].get("users").is_none());
+        assert!(page.get("deferredProps").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a framework-neutral sync props container for lazy, optional, deferred, always, and once props
- route Rocket and Axum page rendering through a shared prop conversion trait while preserving serializable props
- update the Axum minimal example and docs for sync lazy/deferred props

## Validation

- cargo fmt --check
- cargo test --all-features
- cargo test --no-default-features --features axum
- cargo check --no-default-features
- cargo clippy --all-features --all-targets -- -D warnings
- cargo clippy --no-default-features --features axum --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps
- cargo test --manifest-path examples/Cargo.toml
- cargo clippy --manifest-path examples/Cargo.toml --all-targets -- -D warnings
- agent-browser smoke test against axum-minimal HTML and Inertia partial reload responses
