### PR TITLE
Tighten adapter dependency floors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
       - run: cargo clippy --all-features --all-targets -- -D warnings
       - run: cargo test --all-features
       - run: cargo check --no-default-features
+      - run: cargo check --no-default-features --features rocket
+      - run: cargo check --no-default-features --features axum
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --no-default-features --no-deps
 
@@ -26,6 +28,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - run: cargo check --all-features
       - run: cargo check --no-default-features
+      - run: cargo check --no-default-features --features rocket
+      - run: cargo check --no-default-features --features axum
 
   example:
     name: Example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.8", optional = true }
-fluent-uri = { version = "0.4", optional = true }
-rocket = { version = "0.5", features = ["json"], optional = true }
+axum = { version = "0.8.9", optional = true }
+fluent-uri = { version = "0.4.1", optional = true }
+rocket = { version = "0.5.1", features = ["json"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tower = { version = "0.5", features = ["util"], optional = true }
+tower = { version = "0.5.3", features = ["util"], optional = true }
 tracing = "0.1"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For Axum applications, enable the `axum` feature instead:
 ```toml
 [dependencies]
 inertia_rs = { version = "0.3.0", default-features = false, features = ["axum"] }
-axum = "0.8"
+axum = "0.8.9"
 ```
 
 ## Rocket Usage

--- a/examples/axum-minimal/Cargo.toml
+++ b/examples/axum-minimal/Cargo.toml
@@ -6,6 +6,6 @@ workspace = "../"
 publish = false
 
 [dependencies]
-axum = "0.8"
+axum = "0.8.9"
 inertia_rs = { path = "../..", default-features = false, features = ["axum"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- declare the currently tested Rocket, Axum, Tower, and URI parser patch floors in the library manifest
- align the Axum example and README dependency snippet with the tested Axum floor
- add explicit Rocket-only and Axum-only feature checks to stable and MSRV CI

## Validation
- cargo fmt --all -- --check
- cargo check --no-default-features
- cargo check --no-default-features --features rocket
- cargo check --no-default-features --features axum
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps
- RUSTDOCFLAGS='-D warnings' cargo doc --no-default-features --no-deps
- cargo test --manifest-path examples/Cargo.toml
- npm ci and npm run build in examples/rocket-svelte/svelte-app
- agent-browser smoke for Rocket HTML/JSON and Axum HTML/JSON

## Review
- Claude reviewed the diff before PR creation and found no blockers.
