### PR TITLE
Add Rocket minimal example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,5 +3,6 @@ resolver = "2"
 members = [
     "axum-minimal",
     "axum-svelte",
+    "rocket-minimal",
     "rocket-svelte"
 ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,11 @@
 
   Demonstration of Rocket + Svelte. See the project's README for details.
 
+* **[`rocket-minimal`](./rocket-minimal)**
+
+  Minimal Rocket integration example with inline HTML and JSON Inertia
+  responses.
+
 * **[`axum-minimal`](./axum-minimal)**
 
   Minimal Axum integration example with HTML and JSON Inertia responses.

--- a/examples/rocket-minimal/Cargo.toml
+++ b/examples/rocket-minimal/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rocket-minimal"
+version = "0.1.0"
+edition = "2021"
+workspace = "../"
+publish = false
+
+[dependencies]
+inertia_rs = { path = "../..", features = ["rocket"] }
+rocket = { version = "0.5.1", features = ["json"] }
+serde = { version = "1", features = ["derive"] }

--- a/examples/rocket-minimal/README.md
+++ b/examples/rocket-minimal/README.md
@@ -1,0 +1,30 @@
+# Rocket Minimal Example
+
+Minimal Rocket integration example for `inertia_rs`.
+
+Run it with:
+
+```sh
+ROCKET_PORT=8001 cargo run --manifest-path examples/Cargo.toml -p rocket-minimal
+```
+
+Open `http://127.0.0.1:8001/hello` for the HTML first-page response. The
+explicit port keeps this example separate from `rocket-svelte`, which uses
+Rocket's default port.
+
+The example also registers a Rocket shared prop with `SharedProps`.
+
+An Inertia request with the matching asset version returns JSON:
+
+```sh
+curl -H 'X-Inertia: true' -H 'X-Inertia-Version: asset-version-1' \
+  http://127.0.0.1:8001/hello
+```
+
+A stale or missing Inertia version returns `409 Conflict` with
+`X-Inertia-Location`.
+
+```sh
+curl -i -H 'X-Inertia: true' -H 'X-Inertia-Version: stale' \
+  http://127.0.0.1:8001/hello
+```

--- a/examples/rocket-minimal/src/main.rs
+++ b/examples/rocket-minimal/src/main.rs
@@ -1,0 +1,46 @@
+#[macro_use]
+extern crate rocket;
+
+use inertia_rs::rocket::{SharedProps, VersionFairing};
+use inertia_rs::Inertia;
+use rocket::response::content::RawHtml;
+use rocket::response::Responder;
+
+#[derive(serde::Serialize)]
+struct Hello {
+    name: String,
+}
+
+#[get("/hello")]
+fn hello() -> Inertia<Hello> {
+    Inertia::response(
+        "Hello",
+        Hello {
+            name: "world".into(),
+        },
+    )
+}
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build()
+        .mount("/", routes![hello])
+        .manage(SharedProps::new().value("appName", "Rocket Minimal"))
+        .attach(VersionFairing::new("asset-version-1", |request, context| {
+            RawHtml(format!(
+                r#"<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rocket Inertia Example</title>
+  </head>
+  <body>
+    <script data-page="app" type="application/json">{}</script>
+    <main id="app">Open this route with an Inertia request to receive JSON.</main>
+  </body>
+</html>"#,
+                context.data_page()
+            ))
+            .respond_to(request)
+        }))
+}


### PR DESCRIPTION
## Summary
- add a no-Node Rocket minimal example with inline HTML rendering
- demonstrate VersionFairing, SharedProps, JSON Inertia responses, and stale-version conflicts
- register the example in the examples workspace and index

## Validation
- cargo fmt --all -- --check
- cargo test --manifest-path examples/Cargo.toml
- cargo check --no-default-features
- cargo check --no-default-features --features rocket
- cargo check --no-default-features --features axum
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps
- RUSTDOCFLAGS='-D warnings' cargo doc --no-default-features --no-deps
- npm ci && npm run build in examples/rocket-svelte/svelte-app
- npm ci && npm run build in examples/axum-svelte/svelte-app
- agent-browser smoke for rocket-minimal HTML, JSON, and stale-version conflict

## Review
- Claude reviewed the example before PR creation, suggested README clarity fixes, and confirmed no blockers remained after revisions.
