### PR TITLE
Polish full-stack examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,8 @@
 
 * **[`rocket-svelte`](./rocket-svelte)**
 
-  Demonstration of Rocket + Svelte. See the project's README for details.
+  Rocket + Svelte 5 + Vite example with shared props, deferred props, optional
+  props, partial reloads, and manifest-derived asset versioning.
 
 * **[`rocket-minimal`](./rocket-minimal)**
 
@@ -16,4 +17,4 @@
 * **[`axum-svelte`](./axum-svelte)**
 
   Demonstration of Axum + Svelte 5 + Vite with manifest-derived asset
-  versioning.
+  versioning, shared props, deferred props, optional props, and partial reloads.

--- a/examples/axum-svelte/README.md
+++ b/examples/axum-svelte/README.md
@@ -7,10 +7,13 @@ reloads from the Svelte client.
 
 ## Build Frontend Assets
 
+From the repository root:
+
 ```sh
-cd svelte-app
+cd examples/axum-svelte/svelte-app
 npm install
 npm run build
+cd ../../..
 ```
 
 ## Start The Server

--- a/examples/axum-svelte/README.md
+++ b/examples/axum-svelte/README.md
@@ -2,6 +2,9 @@
 
 Small Axum + Svelte 5 + Inertia example.
 
+The page demonstrates shared props, deferred props, optional props, and partial
+reloads from the Svelte client.
+
 ## Build Frontend Assets
 
 ```sh

--- a/examples/axum-svelte/src/main.rs
+++ b/examples/axum-svelte/src/main.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tower_http::services::ServeDir;
 
 #[derive(Clone, Debug)]
@@ -61,6 +62,21 @@ fn load_assets() -> Assets {
     }
 }
 
+fn generated_at() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after the Unix epoch")
+        .as_secs()
+}
+
+fn example_stats(adapter: &'static str) -> serde_json::Value {
+    serde_json::json!({
+        "adapter": adapter,
+        "deferred": true,
+        "generatedAt": generated_at(),
+    })
+}
+
 async fn hello(request: InertiaRequest) -> Result<Response, InertiaError> {
     // InertiaRequest keeps extension snapshots for shared-prop providers, so
     // this example registers SharedProps even though the assets are separate.
@@ -74,8 +90,17 @@ async fn hello(request: InertiaRequest) -> Result<Response, InertiaError> {
             "Hello",
             InertiaProps::new()
                 .value("name", "world")
-                .defer("stats", || 42)
-                .optional("debug", || "partial"),
+                .value(
+                    "message",
+                    "Rendered by Axum and hydrated by Svelte through Inertia.",
+                )
+                .defer("stats", || example_stats("Axum"))
+                .optional("debug", || {
+                    serde_json::json!({
+                        "partialReload": true,
+                        "loadedBy": "X-Inertia-Partial-Data: debug",
+                    })
+                }),
         ),
         |context| {
             let style = assets.style_path.as_deref().map_or_else(String::new, |path| {
@@ -112,7 +137,17 @@ async fn main() {
     let app = Router::new()
         .route("/hello", get(hello))
         .nest_service("/public", ServeDir::new(public_dir))
-        .layer(Extension(SharedProps::new().value("appName", "Axum Svelte")))
+        .layer(Extension(
+            SharedProps::new()
+                .value("appName", "Axum Svelte")
+                .value(
+                    "auth.user",
+                    serde_json::json!({
+                        "name": "Grace Hopper",
+                        "role": "Example user",
+                    }),
+                ),
+        ))
         .layer(Extension(assets.clone()))
         .layer(VersionLayer::new(assets.version.clone()));
 

--- a/examples/axum-svelte/svelte-app/src/Pages/Hello.svelte
+++ b/examples/axum-svelte/svelte-app/src/Pages/Hello.svelte
@@ -1,8 +1,90 @@
 <script>
-  let { appName, name } = $props()
+  import { router } from '@inertiajs/svelte'
+
+  let {
+    appName = 'Inertia Example',
+    auth = {},
+    name = 'world',
+    message = '',
+    stats,
+    debug,
+  } = $props()
+
+  let loading = $state(null)
+
+  const formatGeneratedAt = seconds => (
+    new Date(seconds * 1000).toLocaleTimeString()
+  )
+
+  const reloadProps = (only, key) => {
+    loading = key
+    router.reload({
+      only,
+      onFinish: () => {
+        loading = null
+      },
+    })
+  }
+
+  const loadDebug = () => {
+    reloadProps(['debug'], 'debug')
+  }
+
+  const loadStats = () => {
+    reloadProps(['stats'], 'stats')
+  }
+
+  const loadBoth = () => {
+    reloadProps(['stats', 'debug'], 'both')
+  }
 </script>
 
 <main>
-  <h1>Hello {name} from {appName}</h1>
-  <p>This page was rendered by Axum and hydrated by Svelte through Inertia.</p>
+  <header class="masthead">
+    <p class="eyebrow">{appName}</p>
+    <h1>Hello {name}</h1>
+    {#if message}
+      <p>{message}</p>
+    {/if}
+  </header>
+
+  <section class="summary" aria-label="Shared props">
+    <span>Signed in as</span>
+    <strong>{auth?.user?.name ?? 'Guest'}</strong>
+    <small>{auth?.user?.role ?? 'No role'}</small>
+  </section>
+
+  <section class="props" aria-label="Route props">
+    <article>
+      <span class="label">Deferred stats</span>
+      {#if stats}
+        <strong>{stats.adapter}</strong>
+        <span>Generated at {formatGeneratedAt(stats.generatedAt)}</span>
+      {:else}
+        <span class="muted">Waiting for a partial reload</span>
+      {/if}
+    </article>
+
+    <article>
+      <span class="label">Optional debug</span>
+      {#if debug}
+        <strong>{debug.loadedBy}</strong>
+        <span>Partial reload: {debug.partialReload ? 'yes' : 'no'}</span>
+      {:else}
+        <span class="muted">Not requested yet</span>
+      {/if}
+    </article>
+  </section>
+
+  <div class="actions">
+    <button type="button" disabled={loading !== null} onclick={loadStats}>
+      {loading === 'stats' ? 'Reloading stats' : 'Reload stats'}
+    </button>
+    <button type="button" disabled={loading !== null} onclick={loadDebug}>
+      {loading === 'debug' ? 'Loading debug' : 'Load debug'}
+    </button>
+    <button type="button" disabled={loading !== null} onclick={loadBoth}>
+      {loading === 'both' ? 'Loading both' : 'Load both'}
+    </button>
+  </div>
 </main>

--- a/examples/axum-svelte/svelte-app/src/global.css
+++ b/examples/axum-svelte/svelte-app/src/global.css
@@ -1,27 +1,137 @@
 html,
 body {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {
   margin: 0;
-  color: #1f2937;
+  color: #111827;
+  background: #f8fafc;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
 }
 
+button {
+  min-height: 44px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 16px;
+  color: #ffffff;
+  background: #0f766e;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #115e59;
+}
+
+button:disabled {
+  cursor: progress;
+  background: #64748b;
+}
+
 main {
-  max-width: 680px;
-  padding: 32px;
+  width: min(760px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
+}
+
+.masthead {
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.label {
+  margin: 0;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
 h1 {
-  margin: 0 0 8px;
-  font-size: 2rem;
+  margin: 6px 0 10px;
+  font-size: 3rem;
+  line-height: 1;
 }
 
 p {
+  max-width: 58ch;
   margin: 0;
-  line-height: 1.5;
+  color: #475569;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.summary,
+.props article {
+  border: 1px solid #d8dee9;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgb(15 23 42 / 0.07);
+}
+
+.summary {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 18px;
+}
+
+.summary span,
+.summary small,
+.props span {
+  color: #64748b;
+}
+
+.summary strong,
+.props strong {
+  color: #111827;
+}
+
+.props {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.props article {
+  display: grid;
+  min-height: 120px;
+  align-content: start;
+  gap: 8px;
+  padding: 18px;
+}
+
+.muted {
+  font-style: italic;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 32px 0;
+  }
+
+  .props {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  button {
+    flex: 1 1 100%;
+  }
 }

--- a/examples/rocket-svelte/README.md
+++ b/examples/rocket-svelte/README.md
@@ -7,16 +7,19 @@ reloads from the Svelte client.
 
 ## Build Frontend Assets
 
+From the repository root:
+
 ```sh
-cd svelte-app
+cd examples/rocket-svelte/svelte-app
 npm install
 npm run build
+cd ../../..
 ```
 
 ## Start The Server
 
 ```sh
-cargo run
+cargo run --manifest-path examples/Cargo.toml -p rocket-svelte
 ```
 
 Then open http://127.0.0.1:8000/hello.

--- a/examples/rocket-svelte/README.md
+++ b/examples/rocket-svelte/README.md
@@ -2,6 +2,9 @@
 
 Small Rocket + Svelte 5 + Inertia example.
 
+The page demonstrates shared props, deferred props, optional props, and partial
+reloads from the Svelte client.
+
 ## Build Frontend Assets
 
 ```sh
@@ -17,3 +20,13 @@ cargo run
 ```
 
 Then open http://127.0.0.1:8000/hello.
+
+An Inertia JSON request with the matching asset version returns the page object:
+
+```sh
+VERSION=$(jq -r '."src/main.js" | ([.file] + (.css // [])) | join("|")' \
+  examples/rocket-svelte/public/build/.vite/manifest.json)
+
+curl -H 'X-Inertia: true' -H "X-Inertia-Version: ${VERSION}" \
+  http://127.0.0.1:8000/hello
+```

--- a/examples/rocket-svelte/src/main.rs
+++ b/examples/rocket-svelte/src/main.rs
@@ -1,16 +1,15 @@
 #[macro_use]
 extern crate rocket;
 
-use inertia_rs::{rocket::VersionFairing, Inertia};
+use inertia_rs::{
+    rocket::{SharedProps, VersionFairing},
+    Inertia, InertiaProps,
+};
 use rocket::fs::FileServer;
 use rocket::response::Responder;
 use rocket_dyn_templates::Template;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::BTreeMap, fs};
-
-#[derive(serde::Serialize)]
-struct Hello {
-    name: String,
-}
 
 #[derive(serde::Deserialize)]
 struct ViteManifestEntry {
@@ -49,13 +48,38 @@ fn vite_manifest_entry() -> ViteManifestEntry {
         .expect("Vite manifest does not contain the src/main.js entrypoint")
 }
 
+fn generated_at() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after the Unix epoch")
+        .as_secs()
+}
+
+fn example_stats(adapter: &'static str) -> serde_json::Value {
+    serde_json::json!({
+        "adapter": adapter,
+        "deferred": true,
+        "generatedAt": generated_at(),
+    })
+}
+
 #[get("/hello")]
-fn hello() -> Inertia<Hello> {
+fn hello() -> Inertia<InertiaProps> {
     Inertia::response(
         "Hello",
-        Hello {
-            name: "world".into(),
-        },
+        InertiaProps::new()
+            .value("name", "world")
+            .value(
+                "message",
+                "Rendered by Rocket and hydrated by Svelte through Inertia.",
+            )
+            .defer("stats", || example_stats("Rocket"))
+            .optional("debug", || {
+                serde_json::json!({
+                    "partialReload": true,
+                    "loadedBy": "X-Inertia-Partial-Data: debug",
+                })
+            }),
     )
 }
 
@@ -70,6 +94,17 @@ fn rocket() -> _ {
         rocket::Config::figment().merge(("template_dir", rocket::fs::relative!("templates")));
 
     rocket::custom(figment)
+        .manage(
+            SharedProps::new()
+                .value("appName", "Rocket Svelte")
+                .value(
+                    "auth.user",
+                    serde_json::json!({
+                        "name": "Ada Lovelace",
+                        "role": "Example user",
+                    }),
+                ),
+        )
         .mount("/", routes![hello])
         .attach(Template::fairing())
         .mount("/public", FileServer::from(rocket::fs::relative!("public")))

--- a/examples/rocket-svelte/svelte-app/src/Pages/Hello.svelte
+++ b/examples/rocket-svelte/svelte-app/src/Pages/Hello.svelte
@@ -1,7 +1,90 @@
 <script>
-  let { name } = $props()
+  import { router } from '@inertiajs/svelte'
+
+  let {
+    appName = 'Inertia Example',
+    auth = {},
+    name = 'world',
+    message = '',
+    stats,
+    debug,
+  } = $props()
+
+  let loading = $state(null)
+
+  const formatGeneratedAt = seconds => (
+    new Date(seconds * 1000).toLocaleTimeString()
+  )
+
+  const reloadProps = (only, key) => {
+    loading = key
+    router.reload({
+      only,
+      onFinish: () => {
+        loading = null
+      },
+    })
+  }
+
+  const loadDebug = () => {
+    reloadProps(['debug'], 'debug')
+  }
+
+  const loadStats = () => {
+    reloadProps(['stats'], 'stats')
+  }
+
+  const loadBoth = () => {
+    reloadProps(['stats', 'debug'], 'both')
+  }
 </script>
 
 <main>
-  <h1>Hello {name}!!</h1>
+  <header class="masthead">
+    <p class="eyebrow">{appName}</p>
+    <h1>Hello {name}</h1>
+    {#if message}
+      <p>{message}</p>
+    {/if}
+  </header>
+
+  <section class="summary" aria-label="Shared props">
+    <span>Signed in as</span>
+    <strong>{auth?.user?.name ?? 'Guest'}</strong>
+    <small>{auth?.user?.role ?? 'No role'}</small>
+  </section>
+
+  <section class="props" aria-label="Route props">
+    <article>
+      <span class="label">Deferred stats</span>
+      {#if stats}
+        <strong>{stats.adapter}</strong>
+        <span>Generated at {formatGeneratedAt(stats.generatedAt)}</span>
+      {:else}
+        <span class="muted">Waiting for a partial reload</span>
+      {/if}
+    </article>
+
+    <article>
+      <span class="label">Optional debug</span>
+      {#if debug}
+        <strong>{debug.loadedBy}</strong>
+        <span>Partial reload: {debug.partialReload ? 'yes' : 'no'}</span>
+      {:else}
+        <span class="muted">Not requested yet</span>
+      {/if}
+    </article>
+  </section>
+
+  <div class="actions">
+    <button type="button" disabled={loading !== null} onclick={loadStats}>
+      {loading === 'stats' ? 'Reloading stats' : 'Reload stats'}
+    </button>
+    <button type="button" disabled={loading !== null} onclick={loadDebug}>
+      {loading === 'debug' ? 'Loading debug' : 'Load debug'}
+    </button>
+    <button type="button" disabled={loading !== null} onclick={loadBoth}>
+      {loading === 'both' ? 'Loading both' : 'Load both'}
+    </button>
+  </div>
 </main>

--- a/examples/rocket-svelte/svelte-app/src/global.css
+++ b/examples/rocket-svelte/svelte-app/src/global.css
@@ -1,63 +1,137 @@
-html, body {
-	position: relative;
-	width: 100%;
-	height: 100%;
+html,
+body {
+  min-height: 100%;
 }
 
 body {
-	color: #333;
-	margin: 0;
-	padding: 8px;
-	box-sizing: border-box;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-}
-
-a {
-	color: rgb(0,100,200);
-	text-decoration: none;
-}
-
-a:hover {
-	text-decoration: underline;
-}
-
-a:visited {
-	color: rgb(0,80,160);
-}
-
-label {
-	display: block;
-}
-
-input, button, select, textarea {
-	font-family: inherit;
-	font-size: inherit;
-	-webkit-padding: 0.4em 0;
-	padding: 0.4em;
-	margin: 0 0 0.5em 0;
-	box-sizing: border-box;
-	border: 1px solid #ccc;
-	border-radius: 2px;
-}
-
-input:disabled {
-	color: #ccc;
+  margin: 0;
+  color: #111827;
+  background: #f8fafc;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
 }
 
 button {
-	color: #333;
-	background-color: #f4f4f4;
-	outline: none;
+  min-height: 44px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 16px;
+  color: #ffffff;
+  background: #0f766e;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #115e59;
 }
 
 button:disabled {
-	color: #999;
+  cursor: progress;
+  background: #64748b;
 }
 
-button:not(:disabled):active {
-	background-color: #ddd;
+main {
+  width: min(760px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 48px 0;
 }
 
-button:focus {
-	border-color: #666;
+.masthead {
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.label {
+  margin: 0;
+  color: #7c3aed;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 6px 0 10px;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+p {
+  max-width: 58ch;
+  margin: 0;
+  color: #475569;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.summary,
+.props article {
+  border: 1px solid #d8dee9;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 45px rgb(15 23 42 / 0.07);
+}
+
+.summary {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 16px;
+  padding: 18px;
+}
+
+.summary span,
+.summary small,
+.props span {
+  color: #64748b;
+}
+
+.summary strong,
+.props strong {
+  color: #111827;
+}
+
+.props {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.props article {
+  display: grid;
+  min-height: 120px;
+  align-content: start;
+  gap: 8px;
+  padding: 18px;
+}
+
+.muted {
+  font-style: italic;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 32px 0;
+  }
+
+  .props {
+    grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  button {
+    flex: 1 1 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- Add shared app/auth props to the Rocket and Axum Svelte examples.
- Show route-local props, deferred stats, optional debug data, and Svelte partial reload controls.
- Refresh the example styling and docs around the full-stack Inertia flows.

## Validation
- cargo fmt --all -- --check
- cargo check --manifest-path examples/Cargo.toml
- npm run build in both Svelte example apps
- cargo check --no-default-features
- cargo check --no-default-features --features rocket
- cargo check --no-default-features --features axum
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features
- RUSTDOCFLAGS='-D warnings' cargo doc --all-features --no-deps
- RUSTDOCFLAGS='-D warnings' cargo doc --no-default-features --no-deps
- cargo test --manifest-path examples/Cargo.toml
- curl assertions for initial and partial Inertia JSON responses in both examples
- agent-browser smoke tests for both pages, partial reload buttons, and mobile overflow